### PR TITLE
Make module look more professional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # WiFi Password Viewer
-A Xposed module to view WiFi Password in Settings.
+An Xposed module to view WiFi passwords in Settings.

--- a/app/src/main/java/com/czbix/xposed/wifipassword/Patch.java
+++ b/app/src/main/java/com/czbix/xposed/wifipassword/Patch.java
@@ -158,7 +158,11 @@ public class Patch implements IXposedHookLoadPackage {
         }
 
         private void addRow(MethodHookParam param, int idPwd, ViewGroup group, final String ssid, final String pwd) {
-            XposedHelpers.callMethod(param.thisObject, "addRow", group, idPwd, "\\(╯-╰)/");
+            String defaultPwd = mContext.getString(R.string.empty_password);
+            if (pwd != defaultPwd) {
+                defaultPwd = new String(new char[pwd.length()]).replace("\0", "·");
+            }
+            XposedHelpers.callMethod(param.thisObject, "addRow", group, idPwd, defaultPwd);
             final View view = group.getChildAt(group.getChildCount() - 1);
 
             view.setOnClickListener(new View.OnClickListener() {
@@ -203,9 +207,9 @@ public class Patch implements IXposedHookLoadPackage {
             for (WifiConfiguration config : list) {
                 if (config.networkId == networkId) {
                     if (config.allowedKeyManagement.get(KeyMgmt.WPA_PSK)) {
-                        return config.preSharedKey;
+                        return config.preSharedKey.replaceAll("^\"|\"$", "");
                     } else {
-                        return config.wepKeys[config.wepTxKeyIndex];
+                        return config.wepKeys[config.wepTxKeyIndex].replaceAll("^\"|\"$", "");
                     }
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="toast_wifi_info_copied">WiFi info copied!</string>
-    <string name="clip_info_format">SSID: %1$s\nPWD: %2$s</string>
-    <string name="empty_password">N/A</string>
+    <string name="toast_wifi_info_copied">SSID and password copied!</string>
+    <string name="clip_info_format">SSID: %1$s\nPassword: %2$s</string>
+    <string name="empty_password">None</string>
     <string name="app_title">WiFi Password</string>
-    <string name="app_desc">View WiFi Password in WiFi Settings</string>
+    <string name="app_desc">View WiFi passwords in Settings</string>
 </resources>


### PR DESCRIPTION
When I install an Xposed module, I expect it to appear as though it could've been a default feature of the operating system. WiFi Password was the best of the WiFi password revealer modules, but didn't quite meet my standards of professionalism, so I've gone ahead and made the following changes:
- Correct grammar in `README.md`.
- Change `app_desc` to match `README.md` description.
- Change `clip_info_format` to use the full word "Password".
- Change `empty_password` to "None" to match "Security: None" in dialogs.
- Change `toast_wifi_info_copied` to tell user exactly what was copied.
- Show `empty_password` without click when password is empty.
- Replace person covering his eyes(?) with the correct number of password dots based on password length.
- Remove leading and trailing quotations from displayed and copied data, as these could lead user to believe quotations are part of the password.
