### PR TITLE
Add google() repo to find the android gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
@@ -15,5 +16,6 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }


### PR DESCRIPTION
Fixes compiling with `./gradlew assembleRelease`:

```
> Could not resolve all files for configuration ':classpath'.
   > Could not find com.android.tools.build:gradle:3.0.1.
     Searched in the following locations:
         https://jcenter.bintray.com/com/android/tools/build/gradle/3.0.1/gradle-3.0.1.pom
         https://jcenter.bintray.com/com/android/tools/build/gradle/3.0.1/gradle-3.0.1.jar
     Required by:
         project :
```